### PR TITLE
force light mode on button when specified

### DIFF
--- a/scss/_close.scss
+++ b/scss/_close.scss
@@ -57,7 +57,9 @@
 @if $enable-dark-mode {
   @include color-mode(dark) {
     .btn-close {
-      @include btn-close-white();
+      &:not([data-bs-theme="light"]) {
+        @include btn-close-white(); 
+      }
     }
   }
 }


### PR DESCRIPTION
### Description

Added logic for making the close button stay in light mode when specified, even if the parent elements are set to dark mode.

### Motivation & Context

This change was specified in this [issue](https://github.com/twbs/bootstrap/issues/39481)

